### PR TITLE
Change message to a template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+- Changed message from static format to template
+
 ## [0.1.0] - 2020-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Flags:
   -h, --help                      help for sensu-snmp-trap-handler
   -H, --host string               The SNMP manager host address (default "127.0.0.1")
   -p, --port int                  The SNMP manager trap port (UDP) (default 162)
-  -t, --varbind-trim int          The SNMP trap varbind value trim length (default 100)
+  -t, --varbind-trim int          The SNMP trap varbind value trim length in characters (default 100)
   -v, --version string            The SNMP version to use (1,2,2c) (default "2")
   -m, --message-template string   The template for the SNMP message (default "{{.Check.State}} - {{.Entity.Name}}/{{.Check.Name}} : {{.Check.Output}}")
 

--- a/README.md
+++ b/README.md
@@ -40,12 +40,14 @@ Available Commands:
   version     Print the version number of this plugin
 
 Flags:
-  -c, --community string   The SNMP Community string to use when sending traps (default "public")
-  -h, --help               help for sensu-snmp-trap-handler
-  -H, --host string        The SNMP manager host address (default "127.0.0.1")
-  -p, --port int           The SNMP manager trap port (UDP) (default 162)
-  -t, --varbind-trim int   The SNMP trap varbind value trim length (default 100)
-  -v, --version string     The SNMP version to use (1,2,2c) (default "2")
+  -c, --community string          The SNMP Community string to use when sending traps (default "public")
+  -h, --help                      help for sensu-snmp-trap-handler
+  -H, --host string               The SNMP manager host address (default "127.0.0.1")
+  -p, --port int                  The SNMP manager trap port (UDP) (default 162)
+  -t, --varbind-trim int          The SNMP trap varbind value trim length (default 100)
+  -v, --version string            The SNMP version to use (1,2,2c) (default "2")
+  -m, --message-template string   The template for the SNMP message (default "{{.Check.State}} - {{.Entity.Name}}/{{.Check.Name}} : {{.Check.Output}}")
+
 
 Use "sensu-snmp-trap-handler [command] --help" for more information about a command.
 ```

--- a/main_test.go
+++ b/main_test.go
@@ -17,6 +17,7 @@ func TestCheckArgs(t *testing.T) {
 	event := corev2.FixtureEvent("entity1", "check1")
 	plugin.Version = "2"
 	plugin.Host = "localhost"
+	plugin.MessageTemplate = "{{.Check.State}} - {{.Entity.Name}}/{{.Check.Name}} : {{.Check.Output}}"
 	assert.NoError(checkArgs(event))
 	plugin.Version = "99"
 	assert.Error(checkArgs(event))

--- a/main_test.go
+++ b/main_test.go
@@ -35,8 +35,10 @@ func TestFormatMessage(t *testing.T) {
 	event.Check.State = "passing"
 	event.Check.Output = "Check Output"
 	plugin.VarbindTrim = 100
-	expectedString := formatMessage(event)
-	assert.Equal(expectedString, "RESOLVED - entity1/check1 : Check Output")
+	plugin.MessageTemplate = "{{.Check.State}} - {{.Entity.Name}}/{{.Check.Name}} : {{.Check.Output}}"
+	expectedString, err := formatMessage(event)
+	assert.NoError(err)
+	assert.Equal(expectedString, "passing - entity1/check1 : Check Output")
 }
 
 func TestTrimOutput(t *testing.T) {


### PR DESCRIPTION
Closes #4 

Change message to a template, allowing customization.

`  -m, --message-template string   The template for the SNMP message (default "{{.Check.State}} - {{.Entity.Name}}/{{.Check.Name}} : {{.Check.Output}}")`

Default produces trap output similar to this (snmptrapd log entry):
```
2020-07-22 14:17:49 <UNKNOWN> [UDP: [172.28.128.1]:52021->[172.28.128.51]:162]:
DISMAN-EVENT-MIB::sysUpTimeInstance = Timeticks: (1595427469) 184 days, 15:44:34.69	SNMPv2-MIB::snmpTrapOID.0 = OID: SNMPv2-SMI::enterprises.45717.1.0	SNMPv2-SMI::enterprises.45717.1.1.1.1 = STRING: "system1.example.com/linux-cpu-check"	SNMPv2-SMI::enterprises.45717.1.1.1.2 = STRING: "failing - system1.example.com/linux-cpu-check : CheckCPU TOTAL CRITICAL: total=100.0 user=45.69 nice..."	SNMPv2-SMI::enterprises.45717.1.1.1.3 = STRING: "system1.example.com"SNMPv2-SMI::enterprises.45717.1.1.1.4 = STRING: "linux-cpu-check"	SNMPv2-SMI::enterprises.45717.1.1.1.5 = INTEGER: 2	SNMPv2-SMI::enterprises.45717.1.1.1.6 = STRING: "CheckCPU TOTAL CRITICAL: total=100.0 user=45.69 nice=0.0 system=54.31 idle=0.0 iowait=0.0 irq=0.0 so..."	SNMPv2-SMI::enterprises.45717.1.1.1.7 = INTEGER: 0	SNMPv2-SMI::enterprises.45717.1.1.1.8 = INTEGER: 1550086284	SNMPv2-SMI::enterprises.45717.1.1.1.9 = INTEGER: 3	SNMPv2-SMI::enterprises.45717.1.1.1.10 = STRING: "192.168.0.0"
```